### PR TITLE
🚑 BiliPlus多项修复

### DIFF
--- a/src/BiliPlus.py
+++ b/src/BiliPlus.py
@@ -109,7 +109,7 @@ class BiliPlusComic(Comic):
             logger.error(f"漫画id:{self.comic_id} 在处理BiliPlus解锁章节数据时失败!\n{e}")
             logger.exception(e)
             mainGUI.message_box.emit(
-                f"《{self.comic_name}》章节：{self.title} 在处理BiliPlus解锁章节图片地址时失败!\n\n更多详细信息请查看日志文件, 或联系开发者！"
+                f"漫画id:{self.comic_id} 在处理BiliPlus解锁章节数据时失败!\n\n更多详细信息请查看日志文件, 或联系开发者！"
             )
 
 ############################################################
@@ -184,6 +184,8 @@ class BiliPlusEpisode(Episode):
                 url, token = img_url.split("?token=")
                 biliplus_imgs_token.append({"url": url, "token": token})
             self.imgs_token = biliplus_imgs_token
+            if biliplus_imgs_token == []:
+                return False
         except Exception as e:
             logger.error(f"《{self.comic_name}》章节：{self.title} 在处理BiliPlus解锁章节图片地址时失败!\n{e}")
             logger.exception(e)

--- a/src/ui/PySide_src/mainWindow.ui
+++ b/src/ui/PySide_src/mainWindow.ui
@@ -398,7 +398,7 @@
                 <item>
                  <widget class="QPushButton" name="pushButton_resolve_detail">
                   <property name="enabled">
-                   <bool>false</bool>
+                   <bool>true</bool>
                   </property>
                   <property name="maximumSize">
                    <size>
@@ -414,7 +414,7 @@
                 <item>
                  <widget class="QPushButton" name="pushButton_biliplus_resolve_detail">
                   <property name="enabled">
-                   <bool>false</bool>
+                   <bool>true</bool>
                   </property>
                   <property name="maximumSize">
                    <size>
@@ -534,7 +534,7 @@
              <bool>true</bool>
             </property>
             <property name="value">
-             <number>100</number>
+             <number>0</number>
             </property>
             <property name="textVisible">
              <bool>true</bool>
@@ -845,7 +845,7 @@
               <widget class="QLabel" name="label_num_thread_count">
                <property name="minimumSize">
                 <size>
-                 <width>110</width>
+                 <width>120</width>
                  <height>0</height>
                 </size>
                </property>

--- a/src/ui/PySide_src/mainWindow_ui.py
+++ b/src/ui/PySide_src/mainWindow_ui.py
@@ -295,14 +295,14 @@ class Ui_MainWindow(object):
         self.h_Layout_biliplus_detail.setObjectName(u"h_Layout_biliplus_detail")
         self.pushButton_resolve_detail = QPushButton(self.widget_biliplus_detail)
         self.pushButton_resolve_detail.setObjectName(u"pushButton_resolve_detail")
-        self.pushButton_resolve_detail.setEnabled(False)
+        self.pushButton_resolve_detail.setEnabled(True)
         self.pushButton_resolve_detail.setMaximumSize(QSize(80, 25))
 
         self.h_Layout_biliplus_detail.addWidget(self.pushButton_resolve_detail)
 
         self.pushButton_biliplus_resolve_detail = QPushButton(self.widget_biliplus_detail)
         self.pushButton_biliplus_resolve_detail.setObjectName(u"pushButton_biliplus_resolve_detail")
-        self.pushButton_biliplus_resolve_detail.setEnabled(False)
+        self.pushButton_biliplus_resolve_detail.setEnabled(True)
         self.pushButton_biliplus_resolve_detail.setMaximumSize(QSize(80, 25))
 
         self.h_Layout_biliplus_detail.addWidget(self.pushButton_biliplus_resolve_detail)
@@ -374,7 +374,7 @@ class Ui_MainWindow(object):
         self.progressBar_total_progress = QProgressBar(self.tab_download)
         self.progressBar_total_progress.setObjectName(u"progressBar_total_progress")
         self.progressBar_total_progress.setEnabled(True)
-        self.progressBar_total_progress.setValue(100)
+        self.progressBar_total_progress.setValue(0)
         self.progressBar_total_progress.setTextVisible(True)
 
         self.h_Layout_total_progress.addWidget(self.progressBar_total_progress)
@@ -576,7 +576,7 @@ class Ui_MainWindow(object):
         self.h_Layout_num_thread.setObjectName(u"h_Layout_num_thread")
         self.label_num_thread_count = QLabel(self.groupBox)
         self.label_num_thread_count.setObjectName(u"label_num_thread_count")
-        self.label_num_thread_count.setMinimumSize(QSize(110, 0))
+        self.label_num_thread_count.setMinimumSize(QSize(120, 0))
         self.label_num_thread_count.setMaximumSize(QSize(16777215, 16777215))
 
         self.h_Layout_num_thread.addWidget(self.label_num_thread_count)


### PR DESCRIPTION
1. 修复BiliPlus爬取章节信息为空后的处理
2. 修复双击我的库存后依旧查询上一个漫画信息，允许单击漫画后查询
3. UI调整（解析按钮和下载进度条）